### PR TITLE
プロフィール画面作成

### DIFF
--- a/app/components/layouts/Header/Header.tsx
+++ b/app/components/layouts/Header/Header.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 
 const Header = async () => {
   const userSession = await getUserSession();
+  const isLoggedIn = userSession ? userSession.is_login : false;
 
   return (
     <div className="divide-y border-gray-200 dark:border-gray-800 border-b bg-blue-900 h-16 flex items-center">
@@ -18,7 +19,7 @@ const Header = async () => {
             <Link href="/ranking" className="font-medium text-white transition-colors hover:text-gray-300">
               ランキング
             </Link>
-            {userSession.is_login ? (
+            {isLoggedIn ? (
               <>
                 <Link href="/profile">プロフィール</Link>
                 <LogoutButton

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,32 @@
+import { fetchProfile } from "@/features/user/api/fetchProfile";
+import UserProfile from "@/features/user/components/UserProfile";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import React from 'react'
+
+const Profile = async () => {
+  const userData = await fetchProfile();
+  if (!userData) {
+    redirect("/login");
+  }
+  const { name, user_high_note: highNote, user_low_note: lowNote, scores, gender } = userData;
+
+  return (
+    <div className="max-w-sm mx-auto mt-10 grig gap-6">
+      <UserProfile
+        name={name}
+        gender={gender}
+        highNote={highNote}
+        lowNote={lowNote}
+        scores={scores}
+      />
+      <div className="flex items-center text-white mt-4">
+        <Link href="/profile/edit" className="bg-black px-4 py-2 rounded">
+          編集
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+export default Profile

--- a/features/user/api/fetchProfile.ts
+++ b/features/user/api/fetchProfile.ts
@@ -1,0 +1,27 @@
+import { axiosInstance } from "@/lib/axios";
+import { cookies } from "next/headers";
+
+export const fetchProfile = async () => {
+  const cookieStore = cookies();
+  const accessToken = cookieStore.get('access-token')?.value;
+  const client = cookieStore.get('client')?.value;
+  const uid = cookieStore.get('uid')?.value;
+
+  if(!accessToken || !client || !uid) {
+    return null;
+  }
+
+  try {
+    const response = await axiosInstance.get('user', {
+      headers: {
+        uid: uid,
+        client: client,
+        "access-token": accessToken
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.log(error);
+    return null;
+  }
+};

--- a/features/user/components/UserProfile.tsx
+++ b/features/user/components/UserProfile.tsx
@@ -1,0 +1,66 @@
+import { Score } from '@/types/interface';
+import React from 'react'
+
+interface UserProfileProps {
+  name: string;
+  gender: string;
+  highNote: { ja_note_name: string, frequency: number } | null;
+  lowNote: { ja_note_name: string, frequency: number } | null;
+  scores: Score[];
+}
+
+const UserProfile: React.FC<UserProfileProps> = ({ name, gender, highNote, lowNote, scores }) => {
+  return (
+    <div>
+      <h1 className="text-center mb-5 text-3xl font-medium text-white">プロフィール</h1>
+
+      <div className="bg-white shadow-md rounded p-4 mt-4">
+        <div className="flex items-center">
+          <h2 className="text-2xl font-semibold">名前：{name}</h2>
+        </div>
+      </div>
+      
+      <div className="bg-white shadow-md rounded p-4 mt-4">
+        <div className="flex items-center">
+          <h2 className="text-2xl font-semibold">性別：{gender}</h2>
+        </div>
+      </div>
+      
+      <div className="bg-white shadow-md rounded p-4 mt-4">
+        <div className="flex items-center">
+          <h2 className="text-2xl font-semibold">音域高：{highNote?.ja_note_name} ({highNote?.frequency} Hz)</h2>
+        </div>
+      </div>
+      
+      <div className="bg-white shadow-md rounded p-4 mt-4">
+        <div className="flex items-center">
+          <h2 className="text-2xl font-semibold">音域低：{lowNote?.ja_note_name} ({lowNote?.frequency} Hz)</h2>
+        </div>
+      </div>
+      
+      <div className="bg-white shadow-md rounded p-4 mt-4">
+        <h2 className="text-2xl font-semibold mt-4">スコア：</h2>
+        <ul>
+          {scores.map((score: Score) => (
+            <li key={score.id} className="mb-2">
+              <div className="flex items-center">
+                <h3 className="text-md font-semibold mr-2">モード：</h3>
+                <p>{score.mode}</p>
+              </div>
+              <div className="flex items-center">
+                <h3 className="text-md font-semibold mr-2">難易度：</h3>
+                <p>{score.difficulty}</p>
+              </div>
+              <div className="flex items-center">
+                <h3 className="text-md font-semibold mr-2">スコア：</h3>
+                <p>{score.score}</p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+export default UserProfile

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -1,23 +1,27 @@
 import { cookies } from 'next/headers';
 import { axiosInstance } from './axios';
 
-const getAllCookies = (): { [key: string]: string } => {
+export const getUserSession = async () => {
   const cookieStore = cookies();
-  const cookieObject = cookieStore.getAll().reduce((acc, cookie) => {
-    acc[cookie.name] = cookie.value;
-    return acc;
-  }, {} as { [key: string]: string });
-  return cookieObject;
-};
+  const uid = cookieStore.get('uid')?.value;
+  const client = cookieStore.get('client')?.value;
+  const accessToken = cookieStore.get('access-token')?.value;
 
-export const getUserSession = async (): Promise<{ [key: string]: string }> => {
-  const cookie = getAllCookies();
-  const response = await axiosInstance.get("auth/sessions", {
-    headers: {
-      uid: cookie["uid"],
-      client: cookie["client"],
-      "access-token": cookie["access-token"]
-    }
-  });
-  return response.data;
+  if (!uid || !client || !accessToken) {
+    return null;
+  }
+
+  try {
+    const response = await axiosInstance.get("auth/sessions", {
+      headers: {
+        uid: uid,
+        client: client,
+        "access-token": accessToken,
+      }
+    });
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching user session:", error);
+    return null; // エラーが発生した場合もnullを返す
+  }
 };

--- a/types/interface.ts
+++ b/types/interface.ts
@@ -1,0 +1,6 @@
+export interface Score {
+  id: number;
+  mode: string;
+  difficulty: string;
+  score: number;
+};


### PR DESCRIPTION
## 概要

- プロフィール画面の実装
- ヘッダーの微修正

## やったこと

- RailsAPIからのユーザー情報をフェッチしたprofileページの実装
- 未ログインユーザーが/profileに訪れた場合はログイン画面へレンダリングするよう実装
- 認証情報がnullの場合のヘッダーの動きを修正

### 実装結果
![profile_page](https://github.com/xxx871/sound_hit_front/assets/146612767/818320f4-0082-4be2-97c1-3960f4b00706)