### PR TITLE
モード選択機能実装

### DIFF
--- a/app/default/page.tsx
+++ b/app/default/page.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const Default = () => {
+  return (
+    <div>Default</div>
+  )
+}
+
+export default Default

--- a/app/harmony/page.tsx
+++ b/app/harmony/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const Harmony = () => {
+  return (
+    <div className="text-white text-center mt-32 grid gap-16">
+      <h1 className="text-8xl">ハモりモード</h1>
+      <h3 className="text-6xl">後日実装予定</h3>
+    </div>
+  )
+}
+
+export default Harmony

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,30 +1,20 @@
+import ModeSelectWithState from "@/features/game/select/components/ModeSelectWithState";
+import { getModes } from "@/lib/api/getModes";
+import { Mode } from "@/types/interface";
 
-import { Button } from "@/components/ui/button";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./components/elements/Select/Select";
+export default async function Home() {
+  const modes: Mode[] = await getModes();
 
-export default function Home() {
   return (
     <main className="text-white">
       <div>
-        <h1 className="text-9xl mt-16 text-center font-palettemosaic font-bold">
+      <h1 className="text-9xl mt-16 text-center font-palettemosaic font-bold">
           おんぴしゃ
         </h1>
       </div>
-      <div className="mt-16 w-72 mx-auto text-2xl font-palettemosaic text-slate-300">
-        <Select>
-          <SelectTrigger className="w-288px]">
-            <SelectValue placeholder="モードせんたく"/>
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="light">つうじょうモード</SelectItem>
-            <SelectItem value="dark">れんしゅうモード</SelectItem>
-            <SelectItem value="system">ハモりモード</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-      <div className="mt-16 w-16 mx-auto font-palettemosaic mb-24">
-        <Button variant="outline">START</Button>
+      <div className="mt-16 flex flex-col items-center justify-center">
+      <ModeSelectWithState modes={modes} />
       </div>
     </main>
-  );
+  )
 }

--- a/app/practice/page.tsx
+++ b/app/practice/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const Practice = () => {
+  return (
+    <div className="text-white text-center mt-32 grid gap-16">
+      <h1 className="text-8xl">練習モード</h1>
+      <h3 className="text-6xl">後日実装予定</h3>
+    </div>
+  )
+}
+
+export default Practice

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-16 w-full items-center justify-between border border-input bg-background px-3 py-2 text-ms ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}

--- a/features/game/select/components/ModeSelectWithState.tsx
+++ b/features/game/select/components/ModeSelectWithState.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { Button } from '@/components/ui/button';
+import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue, SelectGroup } from '@/components/ui/select';
+import { Mode } from '@/types/interface';
+import { useRouter } from 'next/navigation';
+import React, { useState } from 'react'
+
+export interface ModeSelectWithStateProps {
+  modes: Mode[];
+}
+
+export const ModeSelectWithState = ({ modes }: ModeSelectWithStateProps) => {
+  const [selectedMode, setSelectedMode] = useState<Mode | null>(null)
+  const router = useRouter();
+
+  const handleModeSelect = (modeId: string) => {
+    const mode = modes.find(mode => mode.id.toString() === modeId);
+    setSelectedMode(mode || null);
+  };
+
+  const handleStartClick = () => {
+    if (selectedMode) {
+      let path = '';
+      switch (selectedMode.id) {
+        case 1:
+          path = '/default';
+          break;
+        case 2:
+          path = '/harmony';
+          break;
+        case 3:
+          path = '/practice';
+          break;
+        default:
+          alert('無効なモードです');
+          return;
+      }
+      router.push(`${path}?mode=${selectedMode.id}`);
+    } else {
+      alert('モードを選択してください');
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center space-y-8">
+      <Select onValueChange={handleModeSelect}>
+        <SelectTrigger className="w-80 h-12 text-lg">
+          <SelectValue placeholder="モードを選択してください" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            {modes.map((mode) => (
+              <SelectItem key={mode.id} value={mode.id.toString()}>
+                {mode.name}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+      <div className="mt-16 mx-auto font-palettemosaic mb-24">
+        <Button
+          variant="outline"
+          className="w-32 h-12 text-lg"
+          onClick={handleStartClick}
+        >
+          START
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default ModeSelectWithState

--- a/lib/api/getModes.ts
+++ b/lib/api/getModes.ts
@@ -1,0 +1,6 @@
+import { axiosInstance } from "../axios"
+
+export const getModes = async () => {
+  const response = await axiosInstance.get("/modes");
+  return response.data;
+};

--- a/types/interface.ts
+++ b/types/interface.ts
@@ -28,3 +28,8 @@ export interface Note {
   ja_note_name: string;
   en_note_name: string;
 };
+
+export interface Mode {
+  id: number;
+  name: string;
+};


### PR DESCRIPTION
## 概要

- トップページでのゲームモード選択機能の実装

## やったこと

- Modeテーブルからデータを取得してプルダウンで選択できるように実装
- モードごとの遷移先のページを作成
- 選択したモードによってそのモードのIdをクエリパラメータとして保存するよう実装

### 実装結果
トップページ
<img width="320" alt="mode_select1" src="https://github.com/xxx871/sound_hit_front/assets/146612767/baba0843-8f01-4984-8cc2-885056e00d3c">

/default
<img width="320" alt="mode_select2" src="https://github.com/xxx871/sound_hit_front/assets/146612767/04e106ed-ea4f-4330-888a-ab724ab7ec41">