### PR TITLE
リザルト画面作成

### DIFF
--- a/app/result/page.tsx
+++ b/app/result/page.tsx
@@ -1,0 +1,17 @@
+import ResultContent from '@/features/game/components/ResultContent';
+import { getProfile } from '@/lib/api/getProfile'
+import React from 'react'
+
+const Result = async () => {
+  const userInfo = await getProfile();
+
+  return (
+    <div>
+      <ResultContent
+        userInfo={userInfo}
+      />
+    </div>
+  )
+}
+
+export default Result

--- a/features/game/api/updateScore.ts
+++ b/features/game/api/updateScore.ts
@@ -1,0 +1,26 @@
+import { axiosInstance } from '@/lib/axios';
+import Cookies from 'js-cookie';
+
+export const updateScore = async (modeId: number, difficultyId: number, score: number) => {
+  const uid = Cookies.get("uid") || '';
+  const client = Cookies.get("client") || '';
+  const accessToken = Cookies.get("access-token") || '';
+
+  try {
+    const response = await axiosInstance.put("scores/update", {
+      mode_id: modeId,
+      difficulty_id: difficultyId,
+      score: score,
+    }, {
+      headers: {
+        'uid': uid,
+        'client': client,
+        'access-token': accessToken
+      }
+    });
+    return response.data;
+  } catch (error) {
+    console.log("Failed to update score", error);
+    throw error;
+  }
+};

--- a/features/game/components/ResultContent.tsx
+++ b/features/game/components/ResultContent.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import { User } from '@/types/interface'
+import { useRouter, useSearchParams } from 'next/navigation';
+import React, { useEffect } from 'react'
+import { updateScore } from '../api/updateScore';
+import { Button } from '@/components/ui/button';
+
+interface resultContentProps {
+  userInfo: User;
+}
+
+const ResultContent: React.FC<resultContentProps> = ({ userInfo }) => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const modeId = parseInt(searchParams.get('modeId') || '0', 10);
+  const difficultyId = parseInt(searchParams.get('difficultyId') || '0', 10);
+  const genderId = parseInt(searchParams.get('genderId') || '', 10);
+  const matchCount = parseInt(sessionStorage.getItem('matchCount') || '0', 10);
+
+  useEffect(() => {
+    if (userInfo && modeId > 0 && difficultyId > 0 && matchCount > 0) {
+      updateScore(modeId, difficultyId, matchCount)
+        .catch(error => console.error("Failed to update score", error));
+    }
+  }, [userInfo, modeId, difficultyId, matchCount]);
+
+  const handleBackToHome = () => {
+    sessionStorage.removeItem('matchCount');
+    router.push('/');
+  };
+
+  const handlePlayAgain= () => {
+    router.push(`/normal?modeId=${modeId}&difficultyId=${difficultyId}&genderId=${genderId}`);
+  }
+
+  return (
+    <main className="text-white">
+      <h1 className="text-center mb-5 text-3xl font-medium mt-4">結果画面</h1>
+      <div className="w-72 mx-auto text-2xl text-slate-300 text-center mt-16">
+        <div>
+          <p>連続で一致した回数: {matchCount}</p>
+        </div>
+        <div className="mt-16">
+          <Button onClick={handleBackToHome} className="mt-4 p-2 bg-blue-500 text-white">
+            トップページへ戻る
+          </Button>
+          <Button onClick={handlePlayAgain}>
+            もう一度遊ぶ
+          </Button>
+        </div>
+      </div>
+    </main>
+  )
+}
+
+export default ResultContent

--- a/features/game/components/VoiceAnalysis.tsx
+++ b/features/game/components/VoiceAnalysis.tsx
@@ -6,9 +6,11 @@ import { Button } from '@/components/ui/button';
 interface VoiceAnalysisProps {
   targetNote: string;
   notes: Note[];
+  onResult: (isMatch: boolean) => void;
+  onPitchDetected: (pitch: number, note: string) => void;
 }
 
-const VoiceAnalysis:React.FC<VoiceAnalysisProps> = ({ targetNote, notes }) => {
+const VoiceAnalysis:React.FC<VoiceAnalysisProps> = ({ targetNote, notes, onResult, onPitchDetected }) => {
   const [isRecording, setIsRecording] = useState<boolean>(false);
   const [analyzing, setAnalyzing] = useState<boolean>(false);
   const [firstDetectedFrequency, setFirstDetectedFrequency] = useState<{ frequency: number, note: string } | null>(null);
@@ -55,6 +57,9 @@ const VoiceAnalysis:React.FC<VoiceAnalysisProps> = ({ targetNote, notes }) => {
             if (pitchesRef.current.length === 0) {
               const closestNote = findClosestNote(pitch);
               setFirstDetectedFrequency({ frequency: pitch, note: closestNote });
+              onPitchDetected(pitch, closestNote);
+              const isMatch = closestNote === targetNote;
+              onResult(isMatch);
             }
             pitchesRef.current.push(pitch);
           }
@@ -73,7 +78,7 @@ const VoiceAnalysis:React.FC<VoiceAnalysisProps> = ({ targetNote, notes }) => {
 
   return (
     <div className="flex flex-col items-center justify-center h-screen">
-      <Button onClick={startRecording} disabled={isRecording} className="mt-16 w-72 text-2xl text-slate-300 text-center">
+      <Button onClick={startRecording} disabled={isRecording} className="mt-4 w-72 text-2xl text-slate-300 text-center">
         {isRecording ? 'Recording...' : 'Start Recording'}
       </Button>
       <div className="text-white mt-4 text-center">

--- a/features/game/hooks/useMatchCount.ts
+++ b/features/game/hooks/useMatchCount.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+
+const useMatchCount = () => {
+  const [matchCount, setMatchCount] = useState<number>(0);
+
+  useEffect(() => {
+    const storedMatchCount = sessionStorage.getItem('matchCount');
+    if (storedMatchCount) {
+      setMatchCount(parseInt(storedMatchCount, 10));
+    }
+  }, []);
+
+  const incrementMatchCount = () => {
+    setMatchCount(prevCount => {
+      const newCount = prevCount + 1;
+      sessionStorage.setItem('matchCount', newCount.toString());
+      return newCount;
+    });
+  };
+
+  const resetMatchCount = () => {
+    setMatchCount(0);
+    sessionStorage.setItem('matchCount', '0');
+  };
+
+  return { matchCount, incrementMatchCount, resetMatchCount };
+};
+
+export default useMatchCount;

--- a/features/game/normal/components/EasyGame.tsx
+++ b/features/game/normal/components/EasyGame.tsx
@@ -38,7 +38,6 @@ const EasyGame: React.FC<EasyGameProps> = ({ userInfo, onPlayNote }) => {
         } else {
           const genderId = parseInt(searchParams.get('genderId') || '', 10);
           if (!isNaN(genderId)) {
-            console.log(`Fetching notes for genderId: ${genderId}`);
             notes = await getGenderNotesRange(genderId);
           }
         }

--- a/features/game/normal/components/GameContainer.tsx
+++ b/features/game/normal/components/GameContainer.tsx
@@ -1,12 +1,14 @@
 "use client"
 
-import { useSearchParams } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import React, { useState } from 'react'
 import EasyGame from './EasyGame';
 import MediumGame from './MediumGame';
 import HardGame from './HardGame';
 import { GameUser, Note } from '@/types/interface';
 import VoiceAnalysis from '../../components/VoiceAnalysis';
+import { Button } from '@/components/ui/button';
+import useMatchCount from '../../hooks/useMatchCount';
 
 interface GameContainerProps {
   userInfo: GameUser;
@@ -16,10 +18,38 @@ interface GameContainerProps {
 const GameContainer: React.FC<GameContainerProps> = ({ userInfo, notes }) => {
   const searchParams = useSearchParams();
   const difficulty = searchParams.get('difficultyId');
-  const [targetNote, setTargetNote] = useState<string | null>(null)
+  const mode = searchParams.get('modeId');
+  const genderId = searchParams.get('genderId');
+  const router = useRouter();
+  const [targetNote, setTargetNote] = useState<string | null>(null);
+  const [isMatch, setIsMatch] = useState<boolean | null>(null);
+  const [detectedPitches, setDetectedPitches] = useState<number[]>([]);
+  const { matchCount, incrementMatchCount, resetMatchCount } = useMatchCount();
 
   const handlePlayNote = (note: string) => {
     setTargetNote(note);
+  };
+
+  const handleAnalysisResult = (result: boolean) => {
+    setIsMatch(result);
+    if (result) {
+      incrementMatchCount();
+    } else {
+      resetMatchCount();
+    }
+  };
+
+  const handlePitchDetected = (pitch: number) => {
+    setDetectedPitches(prevPitches => [...prevPitches, pitch]);
+  };
+
+  const handleResultClick = () => {
+    const queryParams = new URLSearchParams({
+      difficultyId: difficulty || '',
+      modeId: mode || '',
+      genderId: genderId || '',
+    }).toString();
+    router.push(`/result?${queryParams}`);
   };
 
   const renderGameComponent = () => {
@@ -40,12 +70,22 @@ const GameContainer: React.FC<GameContainerProps> = ({ userInfo, notes }) => {
     <div className="text-white">
       <div>
         {renderGameComponent()}
-        <h2 className="text-white text-center mt-16">音が流れた後、ボタンを押して音声を入力</h2>
+        <h2 className="text-white text-center mt-10">音が流れた後、ボタンを押して音声を入力</h2>
         {targetNote && (
           <VoiceAnalysis
             targetNote={targetNote}
             notes={notes}
+            onResult={handleAnalysisResult}
+            onPitchDetected={handlePitchDetected}
           />
+        )}
+        {isMatch !== null && (
+          <div className="w-72 mx-auto text-2xl text-slate-300 text-center">
+            <div>{isMatch ? '一致' : '不一致'}</div>
+            <Button onClick={handleResultClick} className="w-72 text-2xl text-center">
+              結果へ進む
+            </Button>
+          </div>
         )}
       </div>
     </div>

--- a/features/game/select/components/DifficultGenderSelect.tsx
+++ b/features/game/select/components/DifficultGenderSelect.tsx
@@ -24,7 +24,7 @@ export const DifficultGenderSelect: React.FC<DifficultGenderSelectProps> = ({
   const [showGenderSelect, setShowGenderSelect] = useState<boolean>(true);
   const router = useRouter();
   const searchParams = useSearchParams();
-  const modeId = searchParams.get('mode');
+  const modeId = searchParams.get('modeId');
 
   useEffect(() => {
     setShowGenderSelect(!userInfo || !userInfo.gender);

--- a/features/game/select/components/ModeSelect.tsx
+++ b/features/game/select/components/ModeSelect.tsx
@@ -36,7 +36,7 @@ export const ModeSelect = ({ modes }: ModeSelectProps) => {
           alert('無効なモードです');
           return;
       }
-      router.push(`${path}?mode=${selectedMode.id}`);
+      router.push(`${path}?modeId=${selectedMode.id}`);
     } else {
       alert('モードを選択してください');
     }


### PR DESCRIPTION
## 概要

- リザルト画面の作成
- 連続で一致した回数が更新されたきプロフィールのスコアを更新

## やったこと

- 入力した音声の周波数から一致かどうかを判定し、連続で一致した回数をリザルト画面で表示
- 一致した回数はセッションストレージに保存
-  連続で一致した回数が更新されたきにプロフィールのスコアを更新
- クエリパラメータとして保存する要素を「~Id」に統一

### 実装結果
音声の一致・不一致判定
<img width="320" alt="check_voice" src="https://github.com/xxx871/sound_hit_front/assets/146612767/fcfdd060-25f1-43ab-af83-ac0743858b28">

リザルト画面
<img width="320" alt="result_page" src="https://github.com/xxx871/sound_hit_front/assets/146612767/59e1ce29-37e4-481a-967e-07be8ad4c880">