### PR TITLE
ランキングページ作成

### DIFF
--- a/app/components/layouts/Header/Header.tsx
+++ b/app/components/layouts/Header/Header.tsx
@@ -17,7 +17,7 @@ const Header = async () => {
           </Link>
           <nav className="flex justify-end items-center space-x-6 text-2xl">
           <ModalTutorial />
-            <Link href="/" className="font-medium text-white transition-colors hover:text-gray-300">
+            <Link href="/ranking" className="font-medium text-white transition-colors hover:text-gray-300">
               ランキング
             </Link>
             {isLoggedIn ? (

--- a/app/ranking/page.tsx
+++ b/app/ranking/page.tsx
@@ -1,0 +1,20 @@
+import UserRankings from '@/features/user/components/UserRankings';
+import { getDifficulties } from '@/lib/api/getDifficulties';
+import { getModes } from '@/lib/api/getModes'
+import React from 'react'
+
+const Ranking = async () => {
+  const modes = await getModes();
+  const difficulties = await getDifficulties();
+
+  return (
+    <>
+      <UserRankings
+        modes={modes}
+        difficulties={difficulties}
+      />
+    </>
+  )
+}
+
+export default Ranking

--- a/features/user/api/getRanking.ts
+++ b/features/user/api/getRanking.ts
@@ -1,0 +1,18 @@
+import { axiosInstance } from "@/lib/axios"
+
+export interface RankingEntry {
+  user: {
+    name: string;
+  };
+  score: number;
+}
+
+export const getRanking = async (selectedMode: number, selectedDifficulty: number): Promise<RankingEntry[]> => {
+  const response = await axiosInstance.get('/scores/ranking', {
+    params: {
+      mode_id: selectedMode,
+      difficulty_id: selectedDifficulty
+    }
+  });
+  return response.data;
+};

--- a/features/user/components/UserRankings.tsx
+++ b/features/user/components/UserRankings.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { Difficult, Mode } from '@/types/interface'
+import React, { useEffect, useState } from 'react'
+import { RankingEntry, getRanking } from '../api/getRanking';
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+
+interface UserRankingsProps {
+  modes: Mode[];
+  difficulties: Difficult[];
+}
+
+const UserRankings: React.FC<UserRankingsProps> = ({ modes, difficulties }) => {
+  const [selectedMode, setSelectedMode] = useState<number | null>(null);
+  const [selectedDifficulty, setSelectedDifficulty] = useState<number | null>(null);
+  const [rankings, setRankings] = useState<RankingEntry[]>([]);
+
+  useEffect(() => {
+    if (selectedMode !== null && selectedDifficulty !== null) {
+      const getUsersRanking = async () => {
+        const rankingData = await getRanking(selectedMode, selectedDifficulty);
+        setRankings(rankingData);
+      };
+
+      getUsersRanking();
+    }
+  }, [selectedMode, selectedDifficulty]);
+
+  return (
+    <div className="text-white max-w-sm mx-auto">
+      <h1 className="text-6xl text-center mt-6">ランキング</h1>
+      <div className="mt-8 text-2xl flex justify-between">
+        <div>
+          <label>モード</label>
+          <Select onValueChange={(value) => setSelectedMode(Number(value))}>
+            <SelectTrigger className="text-lg text-slate-300 w-40">
+              <SelectValue placeholder="モード選択" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {modes.map((mode) => (
+                  <SelectItem key={mode.id} value={mode.id.toString()}>
+                    {mode.name}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        </div>
+        <div>
+          <label>難易度</label>
+          <Select onValueChange={(value) => setSelectedDifficulty(Number(value))}>
+            <SelectTrigger className="text-lg text-slate-300 w-40">
+              <SelectValue placeholder="難易度選択" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {difficulties.map((difficulty) => (
+                  <SelectItem key={difficulty.id} value={difficulty.id.toString()}>
+                    {difficulty.name}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div className="mt-8 text-2xl">
+        {rankings.length > 0 ? (
+          rankings.map((ranking, index) => (
+            <div key={index} className="mb-2">
+              <p>No.{index + 1} {ranking.user.name} {ranking.score}回</p>
+            </div>
+          ))
+        ) : (
+          <p>ランキングデータがありません。</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default UserRankings

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,6 +7,7 @@ const config = {
     './components/**/*.{ts,tsx}',
     './app/**/*.{ts,tsx}',
     './src/**/*.{ts,tsx}',
+    './features/**/*.{ts,tsx}',
 	],
   prefix: "",
   theme: {


### PR DESCRIPTION
## 概要

- ランキングページの作成

## やったこと

- 各モード・各難易度の上位10名のスコアと難易度を表示
- プルダウンからモードと難易度を選んだ場合にAPIにリクエストを送るように実装
- /features以下のファイルもtailwindがバンドルするようにtailwind.config.tsを編集

### 実装結果
ランキングページ
![ranking_page](https://github.com/xxx871/sound_hit_front/assets/146612767/1a529ab2-4227-4b50-8412-65fd557d7d32)