### PR TITLE
難易度「簡単」の実装

### DIFF
--- a/features/game/hooks/useGameLogic.ts
+++ b/features/game/hooks/useGameLogic.ts
@@ -1,0 +1,72 @@
+import { GameUser, Note } from "@/types/interface";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { getUserNotesRange } from "../api/getUserNotesRange";
+import { getGenderNotesRange } from "../api/getGenderNotesRange";
+import * as Tone from "tone";
+
+export const useGameLogic = (userInfo: GameUser, filterSharpNotes: boolean = false) => {
+  const [note, setNote] = useState<Note | null>(null);
+  const [noteInfo, setNoteInfo] = useState<{ en_note_name: string; ja_note_name: string; frequency: number } | null>(null);
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const initialize = async () => {
+      try {
+        let notes = await getNotes(userInfo, searchParams);
+        if(filterSharpNotes) {
+          notes = notes.filter(note => !note.en_note_name.includes('#'));
+        }
+        if (notes.length === 0) {
+          console.error("No notes available after filtering");
+          return;
+        }
+        const randomNote = getRandomNote(notes);
+        setNote(randomNote);
+        setNoteInfo({
+          en_note_name: randomNote.en_note_name,
+          ja_note_name: randomNote.ja_note_name,
+          frequency: randomNote.frequency
+        });
+      } catch (error) {
+        console.error("Error during initialization:", error);
+      }
+    };
+    initialize();
+  }, [userInfo, filterSharpNotes, searchParams]);
+
+  
+  const playNote = async (onPlayNote: (note: string) => void) => {
+    if (!note) {
+      console.error("No note to play", Error);
+      return;
+    }
+    await Tone.start();
+    const synth = new Tone.PolySynth().toDestination();
+    synth.triggerAttackRelease(note.en_note_name, '1s');
+    onPlayNote(note.en_note_name);
+  };
+
+  return { note, noteInfo, playNote };
+};
+
+const getNotes = async (userInfo: GameUser, searchParams: URLSearchParams): Promise<Note[]> => {
+  if (userInfo) {
+    const { user_high_note, user_low_note, gender_id } = userInfo;
+    if (user_high_note && user_low_note) {
+      return await getUserNotesRange(user_high_note.en_note_name, user_low_note.en_note_name);
+    } else if (gender_id !== undefined) {
+      return await getGenderNotesRange(gender_id);
+    }
+  }
+  const genderId = parseInt(searchParams.get('genderId') || '', 10);
+  if (!isNaN(genderId)) {
+    return await getGenderNotesRange(genderId);
+  }
+  throw new Error("Unable to get notes");
+};
+
+const getRandomNote = (notes: Note[]): Note => {
+  const randomIndex = Math.floor(Math.random() * notes.length);
+  return notes[randomIndex];
+};

--- a/features/game/normal/components/EasyGame.tsx
+++ b/features/game/normal/components/EasyGame.tsx
@@ -1,85 +1,20 @@
-import { Note, GameUser } from '@/types/interface';
-import React, { useEffect, useState } from 'react'
-import * as Tone from "tone";
-import { getUserNotesRange } from '../../api/getUserNotesRange';
-import { getGenderNotesRange } from '../../api/getGenderNotesRange';
-import { useSearchParams } from 'next/navigation';
-import { Button } from '@/components/ui/button';
+import { GameUser } from '@/types/interface';
+import React from 'react'
+import { useGameLogic } from '../../hooks/useGameLogic';
+import GameBase from './GameBase';
 
 interface EasyGameProps {
   onPlayNote: (note: string) => void;
   userInfo: GameUser;
 }
 
-const getRandomNote = (notes: Note[]): Note => {
-  const randomIndex = Math.floor(Math.random() * notes.length);
-  return notes[randomIndex];
+const EasyGame: React.FC<EasyGameProps> = ({ userInfo, onPlayNote}) => {
+  const { noteInfo, playNote } = useGameLogic(userInfo, true);
+  return (
+    <div>
+      <GameBase noteInfo={noteInfo} playNote={() => playNote(onPlayNote)} />
+    </div>
+  );
 };
 
-const EasyGame: React.FC<EasyGameProps> = ({ userInfo, onPlayNote }) => {
-  const [note, setNote] = useState<Note | null>(null);
-  const [noteInfo, setNoteInfo] = useState<{ en_note_name: string; ja_note_name: string; frequency: number } | null>(null);
-  const searchParams = useSearchParams();
-
-  useEffect(() => {
-    const initialize = async () => {
-      try {
-        let notes: Note[] = [];
-
-        if (userInfo) {
-          const { user_high_note, user_low_note, gender, gender_id } = userInfo;
-          if (user_high_note && user_low_note) {
-            notes = await getUserNotesRange(user_high_note.en_note_name, user_low_note.en_note_name)
-          } else if (gender_id !== undefined) {
-            notes = await getGenderNotesRange(gender_id!);
-          } else {
-            console.log("Gender ID is undefined.");
-          }
-        } else {
-          const genderId = parseInt(searchParams.get('genderId') || '', 10);
-          if (!isNaN(genderId)) {
-            notes = await getGenderNotesRange(genderId);
-          }
-        }
-        if (notes.length === 0) {
-          console.error("No notes available after filtering");
-          return;
-        }
-        const randomNote = getRandomNote(notes);
-        setNote(randomNote);
-      } catch (error) {
-        console.error('Error during initialization:', error);
-      }
-    };
-    initialize();
-  }, [userInfo]);
-
-  const playNote = async () => {
-    if (!note) {
-      console.log("No note to play", Error);
-      return;
-    }
-    await Tone.start();
-    setNoteInfo({ en_note_name: note.en_note_name, ja_note_name: note.ja_note_name, frequency: note.frequency });
-    const synth = new Tone.PolySynth().toDestination();
-    synth.triggerAttackRelease(note.en_note_name, '1s');
-    onPlayNote(note.en_note_name);
-  };
-
-  return (
-    <main className="text-white">
-      <div className="mt-16 w-72 mx-auto text-2xl text-slate-300 text-center">
-        <Button variant="outline" onClick={playNote}>音を再生</Button>
-        {noteInfo && (
-          <div className="mt-4 text-center">
-            <p>{`現在の音: ${noteInfo.en_note_name}`}</p>
-            <p>{`周波数: ${noteInfo.frequency}`}</p>
-            <p>{`日本語の音名: ${noteInfo.ja_note_name}`}</p>
-          </div>
-        )}
-      </div>
-    </main>
-  )
-}
-
-export default EasyGame
+export default EasyGame;

--- a/features/game/normal/components/GameBase.tsx
+++ b/features/game/normal/components/GameBase.tsx
@@ -1,0 +1,38 @@
+import { Button } from '@/components/ui/button';
+import React from 'react';
+
+export interface NoteInfoProps {
+  en_note_name: string;
+  ja_note_name: string;
+  frequency: number;
+}
+
+interface GameBaseProps {
+  noteInfo: NoteInfoProps | null;
+  playNote: () => void;
+  showPlayButton?: boolean;
+  children?: React.ReactNode;
+}
+
+const GameBase: React.FC<GameBaseProps> = ({ noteInfo, playNote, showPlayButton = true, children }) => {
+  return (
+    <main className="text-white">
+      <div className="mt-16 w-72 mx-auto text-2xl text-slate-300 text-center">
+        {showPlayButton && (
+          <Button variant="outline" onClick={playNote}>音を再生</Button>
+        )}
+        {noteInfo && (
+        <div className="mt-4 text-center">
+          <p>現在の音: {noteInfo.en_note_name}</p>
+          <p>周波数: {noteInfo.frequency}</p>
+          <p>日本語の音名: {noteInfo.ja_note_name}</p>
+        </div>
+      )}
+      <h2 className="text-white text-center mt-10">ボタンを押して音声を入力</h2>
+      {children}
+      </div>
+    </main>
+  );
+};
+
+export default GameBase;

--- a/features/game/normal/components/GameContainer.tsx
+++ b/features/game/normal/components/GameContainer.tsx
@@ -60,7 +60,7 @@ const GameContainer: React.FC<GameContainerProps> = ({ userInfo, notes }) => {
       case 1:
         return <EasyGame userInfo={userInfo} onPlayNote={handlePlayNote}/>
       case 2:
-        return <MediumGame />
+        return <MediumGame userInfo={userInfo} onPlayNote={handlePlayNote}/>
       case 3:
         return <HardGame />
       default:
@@ -79,6 +79,7 @@ const GameContainer: React.FC<GameContainerProps> = ({ userInfo, notes }) => {
             notes={notes}
             onResult={handleAnalysisResult}
             onPitchDetected={handlePitchDetected}
+            difficulty={difficulty}
           />
         )}
         {isMatch !== null && (
@@ -95,7 +96,7 @@ const GameContainer: React.FC<GameContainerProps> = ({ userInfo, notes }) => {
         )}
       </div>
     </div>
-  )
-}
+  );
+};
 
-export default GameContainer
+export default GameContainer;

--- a/features/game/normal/components/MediumGame.tsx
+++ b/features/game/normal/components/MediumGame.tsx
@@ -1,12 +1,21 @@
+import { GameUser } from '@/types/interface';
 import React from 'react'
+import { useGameLogic } from '../../hooks/useGameLogic';
+import GameBase from './GameBase';
 
-const MediumGame = () => {
-  return (
-    <div className="text-white text-center mt-32 grid gap-16">
-      <h1 className="text-8xl">難易度：普通</h1>
-      <h3 className="text-6xl">後日実装予定</h3>
-    </div>
-  )
+interface MediumGameProps {
+  onPlayNote: (note: string) => void;
+  userInfo: GameUser;
 }
 
-export default MediumGame
+const MediumGame: React.FC<MediumGameProps> = ({ userInfo, onPlayNote }) => {
+  const { noteInfo, playNote } = useGameLogic(userInfo);
+
+  return (
+    <div>
+      <GameBase noteInfo={noteInfo} playNote={() => playNote(onPlayNote)} />;
+    </div>
+  );
+};
+
+export default MediumGame;


### PR DESCRIPTION
## 概要

- 難易度「簡単」の実装

## やったこと

- 以前の「簡単」モードを「普通」モードに移行
- 「簡単」モードとして半音が出題・判定されないように実装
- 共通処理をhooks/useGameLogicコンポーネントに集約
- 共通レイアウトをGameBase.tsxに集約