### PR TITLE
ログインユーザー性別未選択時の処理修正

### DIFF
--- a/features/game/hooks/useGameLogic.ts
+++ b/features/game/hooks/useGameLogic.ts
@@ -51,26 +51,22 @@ export const useGameLogic = (userInfo: GameUser, filterSharpNotes: boolean = fal
 };
 
 const getNotes = async (userInfo: GameUser, searchParams: URLSearchParams): Promise<Note[]> => {
-  if (userInfo) {
-    const { user_high_note, user_low_note, gender_id } = userInfo;
-    if (user_high_note && user_low_note) {
-      const notes = await getUserNotesRange(user_high_note.en_note_name, user_low_note.en_note_name);
-      return notes;
-    } else if (!user_high_note && !user_low_note || gender_id !== null) {
-      const notes = await getGenderNotesRange(gender_id);
-      return notes;
-    } else if (!user_high_note && !user_low_note && !gender_id) {
-      const genderId = parseInt(searchParams.get('genderId') || '', 10);
-      const notes = await getGenderNotesRange(genderId);
-      return notes;
-    }
+  const urlGenderId = parseInt(searchParams.get('genderId') || '', 10);
+
+  if (userInfo?.user_high_note && userInfo?.user_low_note) {
+    return await getUserNotesRange(userInfo.user_high_note.en_note_name, userInfo.user_low_note.en_note_name);
   }
-  const genderId = parseInt(searchParams.get('genderId') || '', 10);
-  if (!isNaN(genderId)) {
-    const notes = await getGenderNotesRange(genderId);
-    return notes;
+
+  if (userInfo?.gender_id !== null && userInfo?.gender_id !== undefined) {
+    return await getGenderNotesRange(userInfo.gender_id);
   }
-  throw new Error("Unable to get notes");
+
+  if (!isNaN(urlGenderId)) {
+    return await getGenderNotesRange(urlGenderId);
+  }
+
+  console.error('No valid parameters found for getNotes');
+  throw new Error("Unable to get notes: No valid user settings or URL parameters found");
 };
 
 const getRandomNote = (notes: Note[]): Note => {

--- a/features/game/select/components/DifficultGenderSelect.tsx
+++ b/features/game/select/components/DifficultGenderSelect.tsx
@@ -40,7 +40,7 @@ export const DifficultGenderSelect: React.FC<DifficultGenderSelectProps> = ({
   };
 
   useEffect(() => {
-    setShowGenderSelect(!userInfo || !userInfo.user_low_note && !userInfo.user_high_note );
+    setShowGenderSelect(!userInfo || !userInfo.user_low_note && !userInfo.user_high_note && !userInfo.gender_id );
   }, [userInfo]);
 
   const handleStartClick = () => {


### PR DESCRIPTION
## 概要

- ログインユーザー性別未選択時の処理修正

## やったこと

- `useGameLogic.ts` のgetNotes関数の処理を下記のとおり変更

  - ログインしているユーザーが音域を持っている場合
  - ログインしているユーザーがgender_idを持っている場合
  - ログインに依らず、クエリパラメータにgenderIdがある場合

- `DifficultGenderSelect.tsx` にて、ユーザーがログインしていない場合と、ログインしているユーザーが音域・性別を持っていないときに性別選択が表示されるように修正